### PR TITLE
Implementation milestones

### DIFF
--- a/stackgvm/README.md
+++ b/stackgvm/README.md
@@ -2,5 +2,12 @@
 
 A 32-bit pure VM intended for use within the TOYTL Engine. This provides support for 32-bit integer, floating point and vector operations where a vector is defined as a triplet of 3 floating point values.
 
-The implementation does not use a register model, nor a traditional stack model. Instead, stack frames are used that are accessible by index positions relative to the current stack frame address.
+- Instructions are implemented as pure byte code comprising of between 1 to 5 bytes typically.
+- Instructions have up to three operands. Generally all dyadic operations have 3, two source operands and a destination.
+- 16-bit values are used for branch targets and identifiers for function IDs, global data references etc. Where these are present in the byte code, they are stored MSB first.
 
+The implementation is not instanced. A single static class forms the basis of the interpreter. This is a deliberate choice as there is no use case within the TOYTL Engine for more than one instance and removing the hidden indirection improves performance.
+
+The implementation is neither a register machine or a pure stack machine. Instead, a stack frame model is used in which every function defines a stack frame that gives each invocation of that function the space required for it's return, parameters and any local temporaries. Instructions operating on the stack frame interpret their operands as offsets.
+
+Since only 32-bit scalar types are supported, the machine allows indirection. Every frame has a pair of indirection pointers that can be assigned an address, permitting instructions that support indirection to do operate directly on the target data.

--- a/stackgvm/README.md
+++ b/stackgvm/README.md
@@ -1,0 +1,6 @@
+# TOYTL StackGVM
+
+A 32-bit pure VM intended for use within the TOYTL Engine. This provides support for 32-bit integer, floating point and vector operations where a vector is defined as a triplet of 3 floating point values.
+
+The implementation does not use a register model, nor a traditional stack model. Instead, stack frames are used that are accessible by index positions relative to the current stack frame address.
+

--- a/stackgvm/source/Makefile.x86_linux
+++ b/stackgvm/source/Makefile.x86_linux
@@ -4,7 +4,7 @@
 BIN      = bin/gamevm_x86_exe
 
 # Compiler settings
-CXXFLAGS = -O3 -Wall -W -m32 -march=native -mfpmath=sse -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_VM_HOST_OS=_VM_HOST_LINUX_INTEL_32
+CXXFLAGS = -O3 -Wall -W -m32 -march=native -mfpmath=sse -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_GVM_HOST_OS=_GVM_HOST_LINUX_INTEL_32 -D_GVM_DEBUGGING_
 
 # Makefile settings
 ARCH     = x86_linux

--- a/stackgvm/source/Makefile.x86_linux_nodebug
+++ b/stackgvm/source/Makefile.x86_linux_nodebug
@@ -1,0 +1,14 @@
+# Project: TOYTL - GVM
+
+# Target
+BIN      = bin/gamevm_x86_nd_exe
+
+# Compiler settings
+CXXFLAGS = -O3 -Wall -W -m32 -march=native -mfpmath=sse -fomit-frame-pointer -fno-exceptions -fexpensive-optimizations -D_GVM_HOST_OS=_GVM_HOST_LINUX_INTEL_32
+
+# Makefile settings
+ARCH     = x86_linux
+MEXT     = $(ARCH)
+
+include interpreter.make
+

--- a/stackgvm/source/gvm_core.cpp
+++ b/stackgvm/source/gvm_core.cpp
@@ -24,7 +24,7 @@ uint32          Interpreter::functionTableSize = 0;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Interpreter::Result Interpreter::init(size_t rSize, size_t fSize, const FuncInfo* table) {
+Result Interpreter::init(size_t rSize, size_t fSize, const FuncInfo* table) {
     if (!table) {
         std::fprintf(stderr, "GVM::Interpreter::init()\n\tFuncInfo table cannot be null\n");
         return MISC_ILLEGAL_VALUE;
@@ -123,7 +123,7 @@ void Interpreter::done() {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Interpreter::Result Interpreter::validateFunctionTable(const FuncInfo* table) {
+Result Interpreter::validateFunctionTable(const FuncInfo* table) {
 
     if (table[0].entryPoint) {
         std::fprintf(stderr, "Function table entry zero must be empty\n");
@@ -181,7 +181,7 @@ Interpreter::Result Interpreter::validateFunctionTable(const FuncInfo* table) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Interpreter::Result Interpreter::invoke(uint16 functionId) {
+Result Interpreter::invoke(uint16 functionId) {
     Result result = enterFunction(0, functionId);
     if (result == SUCCESS) {
         result = run();
@@ -191,7 +191,7 @@ Interpreter::Result Interpreter::invoke(uint16 functionId) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Interpreter::Result Interpreter::enterFunction(const uint8* returnAddress, uint16 functionId) {
+Result Interpreter::enterFunction(const uint8* returnAddress, uint16 functionId) {
     if (functionId == 0 || functionId > functionTableSize) {
         std::fprintf(
             stderr,
@@ -241,7 +241,7 @@ Interpreter::Result Interpreter::enterFunction(const uint8* returnAddress, uint1
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Interpreter::Result Interpreter::enterClosure(const uint8* returnAddress, int16 branch, uint8 frameSize) {
+Result Interpreter::enterClosure(const uint8* returnAddress, int16 branch, uint8 frameSize) {
     if (callStack < callStackTop) {
         uint32 currentFrameSize = callStack->frameSize;
         if (frameStack + currentFrameSize > frameStackTop) {
@@ -280,7 +280,7 @@ Interpreter::Result Interpreter::enterClosure(const uint8* returnAddress, int16 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Interpreter::Result Interpreter::exitFunction() {
+Result Interpreter::exitFunction() {
 
     if (callStack > callStackBase) {
         const uint8* returnTo = callStack->returnAddress;

--- a/stackgvm/source/gvm_run.cpp
+++ b/stackgvm/source/gvm_run.cpp
@@ -57,7 +57,7 @@ using namespace GVM;
 // Return address
 #define RTA(size)  (programCounter + (size))
 
-Interpreter::Result Interpreter::run() {
+Result Interpreter::run() {
 
 forever:
     FETCH {

--- a/stackgvm/source/include/gvm_core.hpp
+++ b/stackgvm/source/include/gvm_core.hpp
@@ -44,6 +44,33 @@ namespace GVM {
         };
     };
 
+    typedef enum {
+        SUCCESS                    = 0,
+
+        // Runtime execution result statuses
+        EXEC_RETURN_TO_HOST        = 1,
+        EXEC_HALT_AND_CATCH_FIRE   = 2,
+        EXEC_CALL_STACK_OVERFLOW   = 3,
+        EXEC_CALL_STACK_UNDERFLOW  = 4,
+        EXEC_FRAME_STACK_OVERFLOW  = 5,
+        EXEC_FRAME_STACK_UNDERFLOW = 6,
+        EXEC_ILLEGAL_CALL_ID       = 7,
+        EXEC_ILLEGAL_HOST_ID       = 8,
+        EXEC_ILLEGAL_DATA_ID       = 9,
+        EXEC_DIVISION_BY_ZERO      = 10,
+
+        // Initialisation failures
+        INIT_OUT_OF_MEMORY         = 100,
+        INIT_TABLE_TOO_BIG         = 101,
+        INIT_INVALID_FRAME_DEF     = 102,
+
+        // Miscellaneous failures
+        MISC_ILLEGAL_VALUE         = 1000
+
+    } Result;
+
+    typedef Result (*NativeCall)(Scalar* stackFrame);
+
     /**
      * CallInfo
      *
@@ -71,31 +98,6 @@ namespace GVM {
                 MAX_STACK_SIZE = FuncInfo::MAX_FRAME_SIZE * MAX_CALL_DEPTH,
                 REDZONE_BUFFER = 128
             };
-
-            typedef enum {
-                SUCCESS                    = 0,
-
-                // Runtime execution result statuses
-                EXEC_RETURN_TO_HOST        = 1,
-                EXEC_HALT_AND_CATCH_FIRE   = 2,
-                EXEC_CALL_STACK_OVERFLOW   = 3,
-                EXEC_CALL_STACK_UNDERFLOW  = 4,
-                EXEC_FRAME_STACK_OVERFLOW  = 5,
-                EXEC_FRAME_STACK_UNDERFLOW = 6,
-                EXEC_ILLEGAL_CALL_ID       = 7,
-                EXEC_ILLEGAL_HOST_ID       = 8,
-                EXEC_ILLEGAL_DATA_ID       = 9,
-                EXEC_DIVISION_BY_ZERO      = 10,
-
-                // Initialisation failures
-                INIT_OUT_OF_MEMORY         = 100,
-                INIT_TABLE_TOO_BIG         = 101,
-                INIT_INVALID_FRAME_DEF     = 102,
-
-                // Miscellaneous failures
-                MISC_ILLEGAL_VALUE         = 1000
-
-            } Result;
 
             static Result  init(size_t rSize, size_t fSize, const FuncInfo* table);
             static Result  invoke(uint16 functionId);

--- a/stackgvm/source/include/gvm_core.hpp
+++ b/stackgvm/source/include/gvm_core.hpp
@@ -11,6 +11,31 @@
 
 namespace GVM {
 
+    typedef enum {
+        SUCCESS                    = 0,
+
+        // Runtime execution result statuses
+        EXEC_RETURN_TO_HOST        = 1,
+        EXEC_HALT_AND_CATCH_FIRE   = 2,
+        EXEC_CALL_STACK_OVERFLOW   = 3,
+        EXEC_CALL_STACK_UNDERFLOW  = 4,
+        EXEC_FRAME_STACK_OVERFLOW  = 5,
+        EXEC_FRAME_STACK_UNDERFLOW = 6,
+        EXEC_ILLEGAL_CALL_ID       = 7,
+        EXEC_ILLEGAL_HOST_ID       = 8,
+        EXEC_ILLEGAL_DATA_ID       = 9,
+        EXEC_DIVISION_BY_ZERO      = 10,
+
+        // Initialisation failures
+        INIT_OUT_OF_MEMORY         = 100,
+        INIT_TABLE_TOO_BIG         = 101,
+        INIT_INVALID_FRAME_DEF     = 102,
+
+        // Miscellaneous failures
+        MISC_ILLEGAL_VALUE         = 1000
+
+    } Result;
+
     /**
      * Scalar
      *
@@ -44,33 +69,6 @@ namespace GVM {
         };
     };
 
-    typedef enum {
-        SUCCESS                    = 0,
-
-        // Runtime execution result statuses
-        EXEC_RETURN_TO_HOST        = 1,
-        EXEC_HALT_AND_CATCH_FIRE   = 2,
-        EXEC_CALL_STACK_OVERFLOW   = 3,
-        EXEC_CALL_STACK_UNDERFLOW  = 4,
-        EXEC_FRAME_STACK_OVERFLOW  = 5,
-        EXEC_FRAME_STACK_UNDERFLOW = 6,
-        EXEC_ILLEGAL_CALL_ID       = 7,
-        EXEC_ILLEGAL_HOST_ID       = 8,
-        EXEC_ILLEGAL_DATA_ID       = 9,
-        EXEC_DIVISION_BY_ZERO      = 10,
-
-        // Initialisation failures
-        INIT_OUT_OF_MEMORY         = 100,
-        INIT_TABLE_TOO_BIG         = 101,
-        INIT_INVALID_FRAME_DEF     = 102,
-
-        // Miscellaneous failures
-        MISC_ILLEGAL_VALUE         = 1000
-
-    } Result;
-
-    typedef Result (*NativeCall)(Scalar* stackFrame);
-
     /**
      * CallInfo
      *
@@ -83,6 +81,8 @@ namespace GVM {
         uint8        frameSize;
         uint8        reserved;
     };
+
+    typedef Result (*HostCall)(Scalar* stackFrame);
 
     /**
      * Interpreter
@@ -99,7 +99,7 @@ namespace GVM {
                 REDZONE_BUFFER = 128
             };
 
-            static Result  init(size_t rSize, size_t fSize, const FuncInfo* table);
+            static Result  init(size_t rSize, size_t fSize, const FuncInfo* table, const HostCall* host);
             static Result  invoke(uint16 functionId);
             static void    done();
 
@@ -121,12 +121,14 @@ namespace GVM {
             static const uint8*    programCounter;
             static const FuncInfo* functionTable;
             static uint32          functionTableSize;
+            static const HostCall* hostFunctionTable;
+            static uint32          hostFunctionTableSize;
 
             static Result enterFunction(const uint8* returnAddress, uint16 functionId);
             static Result enterClosure(const uint8* returnAddress, int16 branch, uint8 frameSize);
             static Result exitFunction();
             static Result run();
-            static Result validateFunctionTable(const FuncInfo* table);
+            static Result validateFunctionTables(const FuncInfo* table, const HostCall* host);
     };
 
 };

--- a/stackgvm/source/include/gvm_core.hpp
+++ b/stackgvm/source/include/gvm_core.hpp
@@ -69,19 +69,6 @@ namespace GVM {
         };
     };
 
-    /**
-     * CallInfo
-     *
-     * Describes the current function under evaluation.
-     */
-    struct CallInfo {
-        const uint8* returnAddress;
-        Scalar*      indirection[2];
-        uint16       functionId;
-        uint8        frameSize;
-        uint8        reserved;
-    };
-
     typedef Result (*HostCall)(Scalar* stackFrame);
 
     /**
@@ -108,6 +95,19 @@ namespace GVM {
             }
 
         private:
+            /**
+             * CallInfo
+             *
+             * Describes the current function under evaluation.
+             */
+            struct CallInfo {
+                const uint8* returnAddress;
+                Scalar*      indirection[2];
+                uint16       functionId;
+                uint8        frameSize;
+                uint8        reserved;
+            };
+
             // Primary allocation for all stack data
             static void*     workingSet;
 

--- a/stackgvm/source/include/gvm_core.hpp
+++ b/stackgvm/source/include/gvm_core.hpp
@@ -127,6 +127,7 @@ namespace GVM {
             static Result enterFunction(const uint8* returnAddress, uint16 functionId);
             static Result enterClosure(const uint8* returnAddress, int16 branch, uint8 frameSize);
             static Result exitFunction();
+            static Result invokeHostFunction(uint16 functionId);
             static Result run();
             static Result validateFunctionTables(const FuncInfo* table, const HostCall* host);
     };

--- a/stackgvm/source/include/gvm_debug.hpp
+++ b/stackgvm/source/include/gvm_debug.hpp
@@ -1,0 +1,14 @@
+/**
+ * TOYTL - GVM
+ *
+ * Twenty Odd Years Too Late Game Virtual Machine
+ */
+
+#ifndef _GVM_DEBUG_HPP_
+    #define _GVM_DEBUG_HPP_
+    #ifdef _GVM_DEBUGGING_
+        #define gvmDebug(...) std::fprintf(stderr, __VA_ARGS__)
+    #else
+        #define gvmDebug(...)
+    #endif
+#endif

--- a/stackgvm/source/include/gvm_untyped.hpp
+++ b/stackgvm/source/include/gvm_untyped.hpp
@@ -59,8 +59,12 @@ IS(ICALL_I) {
 }
 
 IS(HCALL) {
-    // Call a host function
-    STEP(2);
+    // Call a host function by ID
+    Result result = invokeHostFunction(SYM(0));
+    if (result != SUCCESS) {
+        EXIT(result);
+    }
+    STEP(3);
     NEXT;
 }
 

--- a/stackgvm/source/include/host_machine.hpp
+++ b/stackgvm/source/include/host_machine.hpp
@@ -4,29 +4,29 @@
  * Twenty Odd Years Too Late Game Virtual Machine
  */
 
-#ifndef _VM_HOST_MACHINE_HPP_
-    #define _VM_HOST_MACHINE_HPP_
+#ifndef _GVM_HOST_MACHINE_HPP_
+    #define _GVM_HOST_MACHINE_HPP_
     #include <cstdlib>
     #ifdef __LP64__
         #error 64-bit targets are not currently supported
     #endif
 
-    #define _VM_HOST_BIG    0
-    #define _VM_HOST_LITTLE 1
+    #define _GVM_HOST_BIG    0
+    #define _GVM_HOST_LITTLE 1
 
     // change this for other systems
-    #define _VM_HOST_AMIGAOS3_68K     1
-    #define _VM_HOST_AMIGAOS3_WARPUP  2
-    #define _VM_HOST_AMIGAOS4_PPC     3
-    #define _VM_HOST_MORPHOS_PPC      4
-    #define _VM_HOST_LINUX_INTEL_32   5
+    #define _GVM_HOST_AMIGAOS3_68K     1
+    #define _GVM_HOST_AMIGAOS3_WARPUP  2
+    #define _GVM_HOST_AMIGAOS4_PPC     3
+    #define _GVM_HOST_MORPHOS_PPC      4
+    #define _GVM_HOST_LINUX_INTEL_32   5
 
     // Target sanity checks
-    #if (_VM_HOST_OS == _VM_HOST_AMIGAOS3_68K)
+    #if (_GVM_HOST_OS == _GVM_HOST_AMIGAOS3_68K)
         #ifdef __PPC__
             #warning PowerPC directive set for AmigaOS 680x0 target, switching to WarpOS
-            #undef _VM_HOST_OS
-            #define _VM_HOST_OS _VM_HOST_AMIGAOS3_WARPUP
+            #undef _GVM_HOST_OS
+            #define _GVM_HOST_OS _GVM_HOST_AMIGAOS3_WARPUP
         #endif
     #endif
 
@@ -50,16 +50,16 @@
     #define FU64 "llu"
 
     // target specific class implementations
-    #if (_VM_HOST_OS == _VM_HOST_LINUX_INTEL_32)
-        #define _VM_HOST_ENDIAN _VM_HOST_LITTLE
+    #if (_GVM_HOST_OS == _GVM_HOST_LINUX_INTEL_32)
+        #define _GVM_HOST_ENDIAN _GVM_HOST_LITTLE
         #include "platforms/machine_linux_generic.hpp"
-    //#elif (_VM_HOST_OS == _VM_HOST_AMIGAOS3_68K)
+    //#elif (_GVM_HOST_OS == _GVM_HOST_AMIGAOS3_68K)
     //    #include "platforms/machine_amiga_68k.hpp"
-    //#elif (_VM_HOST_OS == _VM_HOST_AMIGAOS3_WARPUP)
+    //#elif (_GVM_HOST_OS == _GVM_HOST_AMIGAOS3_WARPUP)
     //    #include "platforms/machine_amiga_wos.hpp"
-    //#elif (_VM_HOST_OS == _VM_HOST_AMIGAOS4_PPC)
+    //#elif (_GVM_HOST_OS == _GVM_HOST_AMIGAOS4_PPC)
     //    #include "platforms/machine_amiga_os4.hpp"
-    //#elif (_VM_HOST_OS == _VM_HOST_MORPHOS_PPC)
+    //#elif (_GVM_HOST_OS == _GVM_HOST_MORPHOS_PPC)
     //    #include "platforms/machine_amiga_mos.hpp"
     #else
         #error Unrecognised Machine

--- a/stackgvm/source/test_interpreter.cpp
+++ b/stackgvm/source/test_interpreter.cpp
@@ -29,9 +29,14 @@ FuncInfo functionTable[] = {
     { 0, 0, 0, 0, 0 }            // Null termimated set
 };
 
+HostCall hostFunctionTable[] = {
+    0,
+    0
+};
+
 int main() {
     std::printf("Max Opcode %d\n", Opcode::_MAX);
-    Interpreter::init(100, 0, functionTable);
+    Interpreter::init(100, 0, functionTable, hostFunctionTable);
     Scalar* stack = Interpreter::stack();
     stack[0].i = 0;
     stack[1].i = 1;

--- a/stackgvm/source/test_interpreter.cpp
+++ b/stackgvm/source/test_interpreter.cpp
@@ -44,7 +44,7 @@ int main() {
         stack[2].i
     );
 
-    Interpreter::Result result = Interpreter::invoke(1);
+    Result result = Interpreter::invoke(1);
 
     std::printf(
         "\nAfter\n\tResult = %d\n\tstack[0] = %d\n\tstack[1] = %d\n\tstack[2] = %d\n",

--- a/stackgvm/source/test_interpreter.cpp
+++ b/stackgvm/source/test_interpreter.cpp
@@ -9,9 +9,15 @@
 
 using namespace GVM;
 
+Result printInteger(Scalar* frame) {
+    std::printf("HOST: printInteger() = %d\n", frame[0].i);
+    return SUCCESS;
+}
+
 uint8 _gvm_test1[] = {
     Opcode::_ADD_LLL, 1, 2, 3, // fs[3] = fs[1] + fs[2]
     Opcode::_CALL,    0, 2,
+    Opcode::_HCALL,   0, 1,    // Call host function (1)
     Opcode::_COPY_LL, 3, 0,    // fs[0] = fs[3]
     Opcode::_RET
 };
@@ -31,6 +37,7 @@ FuncInfo functionTable[] = {
 
 HostCall hostFunctionTable[] = {
     0,
+    printInteger,
     0
 };
 


### PR DESCRIPTION
### Debugging
Added variadic gvmDebug() macro that is defined according to the _GVM_DEBUGGING_ flag.
- When disabled, all gvmDebug() macros are empty.
- When enabled, all gvmDebug() macros emit a std::fprintf() to stderr

Do not add expressions with side effects (eg function calls, increments, etc) into the parameters passed to gvmDebug(). Doing so will result in different behaviour when debugging is turned off as those expressions will not be expanded.

### Host functions
Implemented initial support for calling host functions