### PR TITLE
Implementation milestone

### DIFF
--- a/stackgvm/source/include/gvm_core.hpp
+++ b/stackgvm/source/include/gvm_core.hpp
@@ -36,6 +36,17 @@ namespace GVM {
 
     } Result;
 
+    // Symbol ID values are 16 bit. When an ID is stored into a Scalar for later use, it is combined with a 2-bit
+    // tag value that identifies it as data, code or host. Whenever a Scalar is used to dereference a Symbol ID,
+    // the tag type is checked.
+    typedef enum {
+        TAG_ILLEGAL        = 0,
+        TAG_DATA_REFERENCE = 1 << 30,
+        TAG_CODE_REFERENCE = 2 << 30,
+        TAG_HOST_REFERNECE = 3 << 30,
+        TAG_MASK_REFERENCE = 3 << 30
+    } SymbolIDTypeTag;
+
     /**
      * Scalar
      *
@@ -46,6 +57,8 @@ namespace GVM {
         uint32  u;
         float32 f;
         Scalar* a;
+        explicit Scalar(int32 i)   : i(i) {}
+        Scalar(float32 f) : f(f) {}
     };
 
     /**
@@ -86,7 +99,7 @@ namespace GVM {
                 REDZONE_BUFFER = 128
             };
 
-            static Result  init(size_t rSize, size_t fSize, const FuncInfo* table, const HostCall* host);
+            static Result  init(size_t rSize, size_t fSize, const FuncInfo* func, const HostCall* host, Scalar** data);
             static Result  invoke(uint16 functionId);
             static void    done();
 
@@ -124,12 +137,16 @@ namespace GVM {
             static const HostCall* hostFunctionTable;
             static uint32          hostFunctionTableSize;
 
+            static Scalar**        dataTable;
+            static uint32          dataTableSize;
+
             static Result enterFunction(const uint8* returnAddress, uint16 functionId);
             static Result enterClosure(const uint8* returnAddress, int16 branch, uint8 frameSize);
             static Result exitFunction();
             static Result invokeHostFunction(uint16 functionId);
+
             static Result run();
-            static Result validateFunctionTables(const FuncInfo* table, const HostCall* host);
+            static Result validateTables(const FuncInfo* func, const HostCall* host, Scalar** data);
     };
 
 };

--- a/stackgvm/source/include/gvm_opcode.hpp
+++ b/stackgvm/source/include/gvm_opcode.hpp
@@ -34,22 +34,35 @@ namespace GVM {
             _BEQ_LI,   // Branch to a signed 16-bit offset if local and indirect values are equal
             _BEQ_II,   // Branch to a signed 16-bit offset if two indirect values are equal
 
-            _ADDR_LL, // Get address of local variable into local variable
-            _ADDR_IL,
-            _ADDR_DL, // Load the address of a global data symbol to a local variable
-            _ADDR_DI, // Load the address of a global data symbol to an indirect variable
-            _ADDR_DX, // Load the address of a global data synbol directly into an index register
-            _ADDR_CL, // Load code synbol to local variable
-            _ADDR_CI, // Load code symbol to indirect variable
+            _ADDR_LL,  // Get address of local variable into local variable
+            _ADDR_I0L, // Get the address of an indirect[0] variable into local variable
+            _ADDR_I1L, // Get the address of an indirect[1] variable into a local variable
 
-            _LOAD_LX, // Load local reference to index register
-            _SAVE_XL, // Save indirection index to local
+            _ADDR_DL, // Load the address of a global data symbol to a local variable
+            _ADDR_DI0, // Load the address of a global data symbol to an indirect[0] variable
+            _ADDR_DI1, // Load the address of a global data symbol to an indirect[1] variable
+
+            _ADDR_D0, // Load the address of a global data synbol directly into indirect[0]
+            _ADDR_D1, // Load the address of a global data synbol directly into indirect[1]
+
+            _ADDR_CL, // Load code synbol to local variable
+            _ADDR_CI0, // Load code symbol to an indirect[0] variable
+            _ADDR_CI1, // Load code symbol to an indirect[1] variable
+
+            _LOAD_L0, // Load local reference directly into indirect[0]
+            _LOAD_L1, // Load local reference directly into indirect[1]
+
+            _SAVE_0L, // Save indirect[0] to local reference
+            _SAVE_1L, // Save indirect[1] to local reference
 
             _LOAD_HL,  // Load host lookup to local
 
             _COPY_LL,  // Copy a local scalar to a local scalar
-            _COPY_IL,  // Copy an indirect scalar to a local
-            _COPY_LI,  // Copy a local scalar to an indirect
+            _COPY_I0L,  // Copy an indirect[0] scalar to a local
+            _COPY_I1L,  // Copy an indirect[1] scalar to a local
+
+            _COPY_LI0,  // Copy a local scalar to indirect[0] variable
+            _COPY_LI1,  // Copy a local scalar to indirect[1] variable
             _COPY_II,  // Copy an indirect scalar to another indirect
 
             _ITOF_LL,  // Cast float to integer

--- a/stackgvm/source/include/gvm_untyped.hpp
+++ b/stackgvm/source/include/gvm_untyped.hpp
@@ -41,8 +41,12 @@ IS(CALL) {
 }
 
 IS(ICALL_L) {
-    // Call a named function by ID stored in local refrence
-    Result result = enterFunction(RTA(2), LOC(0).u);
+    // Call a named function by ID stored in local refrence. Must be tagged with TAG_CODE_REFERENCE
+    uint32 functionTag = LOC(0).u;
+    if ((functionTag & TAG_MASK_REFERENCE) != TAG_CODE_REFERENCE) {
+        EXIT(EXEC_ILLEGAL_CALL_ID);
+    }
+    Result result = enterFunction(RTA(2), functionTag & 0xFFFF);
     if (result != SUCCESS) {
         EXIT(result);
     }
@@ -50,8 +54,12 @@ IS(ICALL_L) {
 }
 
 IS(ICALL_I) {
-    // Call a named function by ID stored in an indirect reference
-    Result result = enterFunction(RTA(3), IX(0, 1).u);
+    // Call a named function by ID stored in an indirect reference. Must be tagged with TAG_CODE_REFERENCE
+    uint32 functionTag = IX(0, 1).u;
+    if ((functionTag & TAG_MASK_REFERENCE) != TAG_CODE_REFERENCE) {
+        EXIT(EXEC_ILLEGAL_CALL_ID);
+    }
+    Result result = enterFunction(RTA(3), functionTag & 0xFFFF);
     if (result != SUCCESS) {
         EXIT(result);
     }
@@ -176,55 +184,124 @@ IS(ADDR_LL) {
     NEXT;
 }
 
-IS(ADDR_IL) {
-    // Get address of indirect variable into local variable
-    STEP(4);
+IS(ADDR_I0L) {
+    // Get address of indirect [0] variable into local variable
+    LOC(1).a = &IX0(0);
+    STEP(3);
+    NEXT;
+}
+
+IS(ADDR_I1L) {
+    // Get address of indirect [1] variable into local variable
+    LOC(1).a = &IX1(0);
+    STEP(3);
     NEXT;
 }
 
 IS(ADDR_DL) {
     // Load the address of a global data symbol to a local variable
+    uint32 symbolId = SYM(0);
+    if (!symbolId) {
+        EXIT(EXEC_ILLEGAL_DATA_ID);
+    }
+    LOC(2).a = dataTable[symbolId];
     STEP(4);
     NEXT;
 }
 
-IS(ADDR_DI) {
-    // Load the address of a global data symbol to an indirect variable
-    STEP(5);
+IS(ADDR_DI0) {
+    // Load the address of a global data symbol to an indirect [0] variable
+    uint32 symbolId = SYM(0);
+    if (!symbolId) {
+        EXIT(EXEC_ILLEGAL_DATA_ID);
+    }
+    IX0(2).a = dataTable[symbolId];
+    STEP(4);
     NEXT;
 }
 
-IS(ADDR_DX) {
+IS(ADDR_DI1) {
+    // Load the address of a global data symbol to an indirect [1] variable
+    uint32 symbolId = SYM(0);
+    if (!symbolId) {
+        EXIT(EXEC_ILLEGAL_DATA_ID);
+    }
+    IX1(2).a = dataTable[symbolId];
+    STEP(4);
+    NEXT;
+}
+
+IS(ADDR_D0) {
     // Load the address of a global data symbol directly into an index register
-    STEP(4);
+    uint32 symbolId = SYM(0);
+    if (!symbolId) {
+        EXIT(EXEC_ILLEGAL_DATA_ID);
+    }
+    IR(0) = dataTable[symbolId];
+    STEP(3);
     NEXT;
 }
+
+IS(ADDR_D1) {
+    // Load the address of a global data symbol directly into an index register
+    uint32 symbolId = SYM(0);
+    if (!symbolId) {
+        EXIT(EXEC_ILLEGAL_DATA_ID);
+    }
+    IR(1) = dataTable[symbolId];
+    STEP(3);
+    NEXT;
+}
+
 
 IS(ADDR_CL) {
     // Load code symbol to local variable
+    LOC(2).u = SYM(0) | TAG_CODE_REFERENCE;
     STEP(4);
     NEXT;
 }
 
-IS(ADDR_CI) {
+IS(ADDR_CI0) {
     // Load code symbol to indirect variable
-    STEP(5);
+    IX0(2).u = SYM(0) | TAG_CODE_REFERENCE;
+    STEP(4);
+    NEXT;
+}
+
+IS(ADDR_CI1) {
+    // Load code symbol to indirect variable
+    IX1(2).u = SYM(0) | TAG_CODE_REFERENCE;
+    STEP(4);
     NEXT;
 }
 
 // Data Movement Operations ////////////////////////////////////////////////////////////////////////////////////////////
 
-IS(LOAD_LX) {
+IS(LOAD_L0) {
     // Load local reference to index register
-    IR(1) = &LOC(0);
-    STEP(3);
+    IR(0) = &LOC(0);
+    STEP(2);
     NEXT;
 }
 
-IS(SAVE_XL) {
+IS(LOAD_L1) {
+    // Load local reference to index register
+    IR(1) = &LOC(0);
+    STEP(2);
+    NEXT;
+}
+
+IS(SAVE_0L) {
     // Save indirection index to local
-    LOC(1).a = IR(0);
-    STEP(3);
+    LOC(0).a = IR(0);
+    STEP(2);
+    NEXT;
+}
+
+IS(SAVE_1L) {
+    // Save indirection index to local
+    LOC(0).a = IR(1);
+    STEP(2);
     NEXT;
 }
 
@@ -241,14 +318,28 @@ IS(COPY_LL) {
     NEXT;
 }
 
-IS(COPY_IL) {
+IS(COPY_I0L) {
     // Copy an indirect scalar to a local
     LOC(1).u = IX0(0).u;
     STEP(3);
     NEXT;
 }
 
-IS(COPY_LI) {
+IS(COPY_I1L) {
+    // Copy an indirect scalar to a local
+    LOC(1).u = IX1(0).u;
+    STEP(3);
+    NEXT;
+}
+
+IS(COPY_LI0) {
+    // Copy a local scalar to an indirect
+    IX0(1).u = LOC(0).u;
+    STEP(3);
+    NEXT;
+}
+
+IS(COPY_LI1) {
     // Copy a local scalar to an indirect
     IX0(1).u = LOC(0).u;
     STEP(3);

--- a/stackgvm/source/test_interpreter.cpp
+++ b/stackgvm/source/test_interpreter.cpp
@@ -14,6 +14,16 @@ Result printInteger(Scalar* frame) {
     return SUCCESS;
 }
 
+Result printFloat(Scalar* frame) {
+    std::printf("HOST: printFloat() = %f\n", frame[0].f);
+    return SUCCESS;
+}
+
+Result printVector(Scalar* frame) {
+    std::printf("HOST: printVector() = { %f, %f, %f }\n", frame[0].f, frame[1].f, frame[2].f);
+    return SUCCESS;
+}
+
 uint8 _gvm_test1[] = {
     Opcode::_ADD_LLL, 1, 2, 3, // fs[3] = fs[1] + fs[2]
     Opcode::_CALL,    0, 2,
@@ -36,14 +46,27 @@ FuncInfo functionTable[] = {
 };
 
 HostCall hostFunctionTable[] = {
-    0,
+    0,                           // Index 0 must be null
     printInteger,
-    0
+    printFloat,
+    0                            // Null terminated set
+};
+
+Scalar dummyVector[] = {
+    0.25f,
+    0.5f,
+    0.75f
+};
+
+Scalar* globalData[] = {
+    0,                           // Index 0 must be null
+    dummyVector,
+    0                            // Null terminated set
 };
 
 int main() {
     std::printf("Max Opcode %d\n", Opcode::_MAX);
-    Interpreter::init(100, 0, functionTable, hostFunctionTable);
+    Interpreter::init(100, 0, functionTable, hostFunctionTable, globalData);
     Scalar* stack = Interpreter::stack();
     stack[0].i = 0;
     stack[1].i = 1;


### PR DESCRIPTION
### Indirection
- Got rid of most (all?) opcodes that take an operand that designates an indirection register and replaced with explicit opcode pairs

### Data
- Implemented global data list. Pass as a null terminated array of arrays of Scalar, as with all other ID referenced tables, index 0 must be null.